### PR TITLE
bug fix: cannot use variable of type error as string in Report struct

### DIFF
--- a/internal/probe.go
+++ b/internal/probe.go
@@ -24,6 +24,13 @@ type Probe struct {
 	Input []string
 }
 
+func errorToString(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
 // Ensures the probe setup is correct.
 func (p Probe) validate() error {
 	if p.Protocols == nil {
@@ -84,7 +91,7 @@ func (p Probe) Do(ctx context.Context) error {
 						report := Report{
 							ProtocolID: proto.String(),
 							Time:       time.Since(start),
-							Error:      err,
+							Error:      errorToString(err),
 							RHost:      rhost,
 							Extra:      extra,
 						}
@@ -103,7 +110,7 @@ func (p Probe) Do(ctx context.Context) error {
 						report := Report{
 							ProtocolID: proto.String(),
 							Time:       time.Since(start),
-							Error:      err,
+							Error:      errorToString(err),
 							RHost:      rhost,
 							Extra:      extra,
 						}


### PR DESCRIPTION
When I wanted to build `up`, compiler complained about using error value as string value in `Report` struct in `probe.go` file.
At first I changed the `Error` type in `Report` struct from `string` to `error` but it resulted to `segmentation fault` error because `error` type could be `nil`.
So I decided to write a function to convert `error` type to `string` literal by testing error against `nil` first. Then It builds and works fine!